### PR TITLE
Fix install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is useful for Storj development and not for Storage Node operator.
 Install the tool:
 
 ```
-go install `storj.io/storj-up
+go install storj.io/storj-up@latest
 ```
 
 Go an empty directory an initialize docker-compose:


### PR DESCRIPTION
This step errors with "version is required when current directory is not in a module".
Adding `@latest` fixes the problem.