### PR TITLE
template/docker-compose: Fix env variable for latest gateway-mt release

### DIFF
--- a/cmd/files/templates/docker-compose.template.yaml
+++ b/cmd/files/templates/docker-compose.template.yaml
@@ -60,7 +60,7 @@ services:
     - --defaults=dev
     environment:
       STORJ_AUTH_TOKEN: super-secret
-      STORJ_AUTH_URL: http://authservice:8888
+      STORJ_AUTH_BASE_URL: http://authservice:8888
       STORJ_DEBUG_ADDR: 0.0.0.0:11111
       STORJ_DEFAULTS: dev
       STORJ_LOG_LEVEL: debug


### PR DESCRIPTION
What: Fix the template

Why: In the latest gateway version one of the parameters was renamed. This PR will fix the template to match the new parameter.