### PR TITLE
cmd/testdata: Adding a command to generate storage usage

### DIFF
--- a/cmd/testdata.go
+++ b/cmd/testdata.go
@@ -17,6 +17,7 @@ import (
 	"storj.io/common/storj"
 	"storj.io/common/uuid"
 	"storj.io/storj/private/currency"
+	"storj.io/storj/satellite/accounting"
 	"storj.io/storj/satellite/compensation"
 	"storj.io/storj/satellite/overlay"
 	"storj.io/storj/satellite/satellitedb"


### PR DESCRIPTION
For now, this just generates bucket storage usage using testdata project-storage command