### PR TITLE
Configure linksharing to run on port 8080

### DIFF
--- a/cmd/files/templates/docker-compose.template.yaml
+++ b/cmd/files/templates/docker-compose.template.yaml
@@ -136,6 +136,7 @@ services:
     - run
     - --defaults=dev
     environment:
+      STORJ_ADDRESS: 0.0.0.0:8080
       STORJ_AUTH_SERVICE_BASE_URL: http://authservice:8888
       STORJ_AUTH_SERVICE_TOKEN: super-secret
       STORJ_DEBUG_ADDR: 0.0.0.0:11111


### PR DESCRIPTION
Port 8080 was the default for linksharing, but it was changed to 20020 with https://github.com/storj/gateway-mt/commit/7a9fd39dd5252e18c646922deee3817535f2378f

As a result, linksharing is broken in storj-up. This change explicitly configures linksharing to run on port 8080.