### PR TITLE
cmd/testdata.go: Make bucket name configurable

### DIFF
--- a/cmd/testdata.go
+++ b/cmd/testdata.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	database, email, bucket, valueattr, period string
+	database, email, bucket, useragent, period string
 	gb                                         = decimal.NewFromInt(1e9)
 	tb                                         = decimal.NewFromInt(1e12)
 	getRate                                    = int64(20)
@@ -66,13 +66,13 @@ func projectUsageCmd() *cobra.Command {
 			if err != nil {
 				return errs.New("invalid date specified specified. accepted format is yyyy-mm: %v", err)
 			}
-			return generateProjectUsage(database, email, bucket, valueattr, usagePeriod)
+			return generateProjectUsage(database, email, bucket, useragent, usagePeriod)
 		},
 	}
 	projectUsageCmd.PersistentFlags().StringVarP(&database, "database", "d", "cockroach://root@localhost:26257/master?sslmode=disable", "Database connection string to generate data")
 	projectUsageCmd.PersistentFlags().StringVarP(&email, "email", "e", "test@storj.io", "the email address of the user to add data for")
 	projectUsageCmd.PersistentFlags().StringVarP(&bucket, "bucket", "b", "storage-bucket", "the bucket to add the usage for")
-	projectUsageCmd.PersistentFlags().StringVarP(&valueattr, "valueattr", "v", "", "value attribution for the bucket")
+	projectUsageCmd.PersistentFlags().StringVarP(&useragent, "useragent", "u", "", "useragent for value attribution")
 	projectUsageCmd.PersistentFlags().StringVarP(&period, "period", "p", "", "the month to add usage for. defaults to the previous month")
 
 	return projectUsageCmd
@@ -84,7 +84,7 @@ func init() {
 	testdataCmd.AddCommand(projectUsageCmd())
 }
 
-func generateProjectUsage(database, email string, bucketname string, valueattr string, period time.Time) error {
+func generateProjectUsage(database, email string, bucketname string, useragent string, period time.Time) error {
 	ctx := context.Background()
 	db, err := satellitedb.Open(ctx, zap.L().Named("db"), database, satellitedb.Options{ApplicationName: "satellite-compensation"})
 	if err != nil {
@@ -119,7 +119,7 @@ func generateProjectUsage(database, email string, bucketname string, valueattr s
 					Name:                        bucketname,
 					ProjectID:                   p.ID,
 					PartnerID:                   uuid.UUID{},
-					UserAgent:                   []byte(valueattr),
+					UserAgent:                   []byte(useragent),
 					Created:                     dayTenOfMonth,
 					PathCipher:                  0,
 					DefaultRedundancyScheme:     storj.RedundancyScheme{},

--- a/cmd/testdata.go
+++ b/cmd/testdata.go
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	database, email, period string
-	gb                      = decimal.NewFromInt(1e9)
-	tb                      = decimal.NewFromInt(1e12)
-	getRate                 = int64(20)
-	auditRate               = int64(10)
-	storageRate             = 0.00000205
+	database, email, bucket, valueattr, period string
+	gb                                         = decimal.NewFromInt(1e9)
+	tb                                         = decimal.NewFromInt(1e12)
+	getRate                                    = int64(20)
+	auditRate                                  = int64(10)
+	storageRate                                = 0.00000205
 )
 
 var testdataCmd = &cobra.Command{
@@ -66,11 +66,13 @@ func projectUsageCmd() *cobra.Command {
 			if err != nil {
 				return errs.New("invalid date specified specified. accepted format is yyyy-mm: %v", err)
 			}
-			return generateProjectUsage(database, email, usagePeriod)
+			return generateProjectUsage(database, email, bucket, valueattr, usagePeriod)
 		},
 	}
 	projectUsageCmd.PersistentFlags().StringVarP(&database, "database", "d", "cockroach://root@localhost:26257/master?sslmode=disable", "Database connection string to generate data")
 	projectUsageCmd.PersistentFlags().StringVarP(&email, "email", "e", "test@storj.io", "the email address of the user to add data for")
+	projectUsageCmd.PersistentFlags().StringVarP(&bucket, "bucket", "b", "storage-bucket", "the bucket to add the usage for")
+	projectUsageCmd.PersistentFlags().StringVarP(&valueattr, "valueattr", "v", "", "value attribution for the bucket")
 	projectUsageCmd.PersistentFlags().StringVarP(&period, "period", "p", "", "the month to add usage for. defaults to the previous month")
 
 	return projectUsageCmd
@@ -82,7 +84,7 @@ func init() {
 	testdataCmd.AddCommand(projectUsageCmd())
 }
 
-func generateProjectUsage(database, email string, period time.Time) error {
+func generateProjectUsage(database, email string, bucketname string, valueattr string, period time.Time) error {
 	ctx := context.Background()
 	db, err := satellitedb.Open(ctx, zap.L().Named("db"), database, satellitedb.Options{ApplicationName: "satellite-compensation"})
 	if err != nil {
@@ -108,13 +110,13 @@ func generateProjectUsage(database, email string, period time.Time) error {
 		lastDayOfMonth := time.Date(period.Year(), period.Month(), 1, 0, 0, 0, 0, period.Location()).AddDate(0, 1, -1)
 
 		var bucket storj.Bucket
-		bucket, err = db.Buckets().GetBucket(ctx, []byte("storage-bucket"), p.ID)
+		bucket, err = db.Buckets().GetBucket(ctx, []byte(bucketname), p.ID)
 		if err != nil {
 			if storj.ErrBucketNotFound.Has(err) {
 				// try to create it instead
 				bucket, err = db.Buckets().CreateBucket(ctx, storj.Bucket{
 					ID:                          byEmail.ID,
-					Name:                        "storage-bucket",
+					Name:                        bucketname,
 					ProjectID:                   p.ID,
 					PartnerID:                   uuid.UUID{},
 					UserAgent:                   nil,

--- a/cmd/testdata.go
+++ b/cmd/testdata.go
@@ -119,7 +119,7 @@ func generateProjectUsage(database, email string, bucketname string, valueattr s
 					Name:                        bucketname,
 					ProjectID:                   p.ID,
 					PartnerID:                   uuid.UUID{},
-					UserAgent:                   nil,
+					UserAgent:                   []byte(valueattr),
 					Created:                     dayTenOfMonth,
 					PathCipher:                  0,
 					DefaultRedundancyScheme:     storj.RedundancyScheme{},


### PR DESCRIPTION
I want to give a customer 2 buckets. One with user agent set for value attribution and one without. I had to modify the code for that. With this code change I am able to specify the bucket name and just call the command twice.

