### PR TITLE
cmd/container: fix volume target path for local-bin

### DIFF
--- a/cmd/container/localbin.go
+++ b/cmd/container/localbin.go
@@ -113,7 +113,7 @@ func mountBinaries(composeService *types.ServiceConfig) error {
 		execName = command
 	}
 	source := filepath.Join(path.Join(dir, subdir), execName)
-	target := filepath.Join("/var/lib/storj/go/bin", execName)
+	target := path.Join("/var/lib/storj/go/bin", execName)
 
 	if err := common.IsRegularFile(source); err != nil {
 		return err


### PR DESCRIPTION
The `storj-up local-bin` command has been modified to use the Unix path separator when generating volume target paths. Previously, the host OS's path separator was used which would produce an invalid path when running the command on a Windows machine. This would cause the volume not to be mounted properly.