### PR TITLE
pkg/files: Add new vuetify poc UI

### DIFF
--- a/pkg/files/docker/storj.Dockerfile
+++ b/pkg/files/docker/storj.Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /var/lib/storj/storj
 COPY --chown=storj ${PATH} .
 
 FROM ${TYPE} AS binaries
-RUN if [ -z "$SKIP_FRONTEND_BUILD" ] ; then cd web/satellite && npm install && npm run build ; fi
+RUN if [ -z "$SKIP_FRONTEND_BUILD" ] ; then cd web/satellite && npm install && npm run build && npm run build-vuetify ; fi
 RUN if [ -z "$SKIP_FRONTEND_BUILD" ] ; then cd web/multinode && npm install && npm install @vue/cli-service && export PATH=$PATH:`pwd`/node_modules/.bin && npm run build ; fi
 RUN if [ -z "$SKIP_FRONTEND_BUILD" ] ; then cd web/storagenode && npm install && npm install @vue/cli-service && export PATH=$PATH:`pwd`/node_modules/.bin && npm run build ; fi
 RUN if [ -z "$SKIP_FRONTEND_BUILD" ] ; then cd satellite/admin/ui && npm install && npm run build ; fi
@@ -50,6 +50,7 @@ ENV STORJ_STORAGENODE_CONSOLE_STATIC_DIR=/var/lib/storj/web/storagenode
 COPY --from=binaries /var/lib/storj/go/bin /var/lib/storj/go/bin
 COPY --from=binaries /var/lib/storj/storj/web/satellite/stati[c] /var/lib/storj/storj/web/satellite/static
 COPY --from=binaries /var/lib/storj/storj/web/satellite/dis[t] /var/lib/storj/storj/web/satellite/dist
+COPY --from=binaries /var/lib/storj/storj/web/satellite/dist_vuetify_poc /var/lib/storj/storj/web/satellite/dist_vuetify_poc
 COPY --from=binaries /var/lib/storj/storj/satellite/admin/ui/build /var/lib/storj/storj/satellite/admin/ui/build
 COPY --from=binaries /var/lib/storj/storj/web/storagenode/stati[c] /var/lib/storj/web/storagenode/static
 COPY --from=binaries /var/lib/storj/storj/web/storagenode/dis[t] /var/lib/storj/web/storagenode/dist


### PR DESCRIPTION
Still requires `storj-up env setenv satellite-api STORJ_CONSOLE_USE_VUETIFY_PROJECT=true`
I didn't include that into the PR because it makes more sense to just switch it on by default in the storj repository.