### PR TITLE
cmd/credentials: update test password

### DIFF
--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -31,7 +31,7 @@ const (
 	encKeyVersionByte = byte(77) // magic number EncryptionKey encoding
 	secKeyVersionByte = byte(78) // magic number SecretKey encoding
 
-	password = "123a123"
+	password = "password"
 	secret   = "Welcome1"
 	filename = ".creds"
 )

--- a/pkg/common/apikey.go
+++ b/pkg/common/apikey.go
@@ -36,7 +36,7 @@ func GetTestAPIKey(satelliteID string) (string, error) {
 	idHash := sha256.Sum256([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	base64Salt := base64.StdEncoding.EncodeToString(idHash[:])
 
-	accessGrant, err := consolewasm.GenAccessGrant(satelliteID, key.Serialize(), "123a123", base64Salt)
+	accessGrant, err := consolewasm.GenAccessGrant(satelliteID, key.Serialize(), "password", base64Salt)
 	if err != nil {
 		return "", errs.Wrap(err)
 	}

--- a/pkg/console.go
+++ b/pkg/console.go
@@ -63,7 +63,7 @@ func (ce *ConsoleEndpoint) tryLogin(ctx context.Context, email string) (string, 
 		Password string `json:"password"`
 	}
 
-	authToken.Password = "123a123"
+	authToken.Password = "password"
 	authToken.Email = email
 
 	res, err := json.Marshal(authToken)
@@ -172,7 +172,7 @@ func (ce *ConsoleEndpoint) createUser(ctx context.Context, regToken string, emai
 
 	registerData.FullName = "Alice"
 	registerData.Email = email
-	registerData.Password = "123a123"
+	registerData.Password = "password"
 	registerData.ShortName = "al"
 	registerData.Secret = regToken
 


### PR DESCRIPTION
The required minimum length for passwords on the satellite will change from 6 to 8. This change uses "password" (8 chars) instead of "123a123" (7 chars).