### PR TITLE
cleanup used space for GitHub Actions (for Integration)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,5 +17,10 @@ jobs:
         run: earthly --ci +test
       - name: Lint
         run: earthly --ci +lint
+      - name: Cleanup used space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          docker-images: false
       - name: Integration
         run: earthly -P --ci +integration-all


### PR DESCRIPTION
This should fix the error "no space left on device: unknown", like there: https://github.com/storj/up/actions/runs/11377876547/job/31652725692