### PR TITLE
pkg/presets.go: add audit rangedloop and repair to build remote command

### DIFF
--- a/pkg/common/presets.go
+++ b/pkg/common/presets.go
@@ -11,17 +11,20 @@ import (
 
 // BuildDict stores the name of the container to build for Storj services.
 var BuildDict = map[string]string{
-	"authservice":     "app-edge",
-	"gateway-mt":      "app-edge",
-	"linksharing":     "app-edge",
-	"satellite-admin": "app-storj",
-	"satellite-api":   "app-storj",
-	"satellite-core":  "app-storj",
-	"satellite-bf":    "app-storj",
-	"satellite-gc":    "app-storj",
-	"storagenode":     "app-storj",
-	"uplink":          "app-storj",
-	"versioncontrol":  "app-storj",
+	"authservice":          "app-edge",
+	"gateway-mt":           "app-edge",
+	"linksharing":          "app-edge",
+	"satellite-admin":      "app-storj",
+	"satellite-api":        "app-storj",
+	"satellite-core":       "app-storj",
+	"satellite-bf":         "app-storj",
+	"satellite-gc":         "app-storj",
+	"satellite-audit":      "app-storj",
+	"satellite-rangedloop": "app-storj",
+	"satellite-repair":     "app-storj",
+	"storagenode":          "app-storj",
+	"uplink":               "app-storj",
+	"versioncontrol":       "app-storj",
 }
 
 // ResolveBuilds returns with the required docker images to build (as keys in the maps).


### PR DESCRIPTION
I want to run `storj-up build remote github -b main storagenode satellite-api satellite-core satellite-audit satellite-rangedloop satellite-repair satellite-admin` but that command was returning an error because it didn't had the full list of all services. This PR will fix that and allow me to run that command and stop modifying the docker compose file by hand. One command and it will work just fine.