### PR TITLE
recipe/spanner.yaml: use spanner database for audit, rangedloop and repair

### DIFF
--- a/pkg/recipe/spanner.yaml
+++ b/pkg/recipe/spanner.yaml
@@ -16,7 +16,13 @@ add:
       SPANNER_EMULATOR_URL: http://localhost:9020/
 modify:
   - match:
-      name: satellite-api,satellite-core,satellite-admin
+      name: 
+        satellite-api,
+        satellite-core,
+        satellite-admin,
+        satellite-audit,
+        satellite-rangedloop,
+        satellite-repair
     config:
       SPANNER_EMULATOR_HOST: 'spanner:9010'
       STORJ_METAINFO_DATABASE_URL: "spanner://projects/test-project/instances/test-instance/databases/metainfo"


### PR DESCRIPTION
audit, rangedloop and repair still had the cockroach connection string. This PR will correct that.